### PR TITLE
Fix/give is verified precedence 

### DIFF
--- a/script.js
+++ b/script.js
@@ -159,10 +159,10 @@ function evaluateBlueCheck() {
 
       const isSmall = checkIfSmall(blueCheckComponent)
   
-      if (nestedProps.isBlueVerified) {
-        changeBlueVerified(blueCheckComponent, isSmall);
-      } else if (nestedProps.isVerified) {
+      if (nestedProps.isVerified) {
         changeVerified(blueCheckComponent, isSmall);
+      } else if (nestedProps.isBlueVerified) {
+        changeBlueVerified(blueCheckComponent, isSmall);
       }
     }
     catch (e) {
@@ -183,10 +183,10 @@ function evaluateBlueCheckProvidesDetails() {
         throw new Error("Change target not found for a 'Provides details' node")
       }
 
-      if (nestedProps.isBlueVerified) {
-        changeBlueVerified(changeTarget, isSmall);
-      } else if (nestedProps.isVerified) {
+      if (nestedProps.isVerified) {
         changeVerified(changeTarget, isSmall);
+      } else if (nestedProps.isBlueVerified) {
+        changeBlueVerified(changeTarget, isSmall);
       }
     } catch (e) {
       console.error("Error getting 'Provides details' react props: ", e)


### PR DESCRIPTION
# Give `isVerified` precedence + hide checkmark if indeterminate (in Twitter Spaces)
- #41 gave `isBlueVerified` precedence over `isVerified`
- This PR reverts precedence, giving precedence back to `isVerifed`
- Bad data in Twitter Spaces is addressed by hiding the checkmark if `isVerified == true && isBlueVerified == true`

Test cases:
- https://twitter.com/WenSpaces/status/1589432228437630976
- https://twitter.com/robinw/status/1590403084513333249

<img width="419" alt="image" src="https://user-images.githubusercontent.com/2031472/201469578-1d8dbc77-9a7e-4134-b8e6-264dc059d5ff.png">
<img width="241" alt="image" src="https://user-images.githubusercontent.com/2031472/201469591-d1c06eb2-1df4-40bd-9bfa-e984f44fa9e4.png">
<img width="422" alt="image" src="https://user-images.githubusercontent.com/2031472/201469585-96ca2646-c788-489a-b997-9ca14b271798.png">
<img width="205" alt="image" src="https://user-images.githubusercontent.com/2031472/201469597-dfc0740b-db83-428f-9500-ccb3f8aa1b21.png">

