### PR TITLE
fix: gap between badge and empty string text

### DIFF
--- a/script.js
+++ b/script.js
@@ -138,11 +138,11 @@ function changeVerified(elm, isSmall, isIndeterminate) {
     elm.setAttribute('data-eight-dollars-status', 'verified');
     return;
   }
-  
+
   const small = REGULAR_BLUE_CHECK_SVG(true, elm.className.baseVal);
   const smallInnerElement = REGULAR_BLUE_CHECK_SVG(false, elm.className.baseVal);
   const big =  `
-    <div style='margin-left: 0.25rem; display: flex; flex-direction: row; align-items: center;${TEXT_ENABLE_BORDER ? ` border-radius: 120px; border: 1px solid #536471;`: ``} padding: 0.1rem 0.4rem 0.1rem 0.2rem; gap: 0.2rem;' aria-label="${VERIFIED_ACCOUNT_ARIA_LABEL}" data-eight-dollars-status="verified">
+    <div style='margin-left: 0.25rem; display: flex; flex-direction: row; align-items: center;${TEXT_ENABLE_BORDER ? ` border-radius: 120px; border: 1px solid #536471;`: ``} padding: 0.1rem 0.4rem 0.1rem 0.2rem; gap: ${TEXT_VERIFIED_LABEL ? 0.2 : 0}rem;' aria-label="${VERIFIED_ACCOUNT_ARIA_LABEL}" data-eight-dollars-status="verified">
       ${smallInnerElement}
       <p style=' font-size: 0.8rem; margin: 0; font-weight: 600;'>${TEXT_VERIFIED_LABEL}</p>
     </div>`;
@@ -172,7 +172,7 @@ function changeBlueVerified(elm, isSmall) {
   const small = MEME_MODE ? `${COMIC_SANS_BLUE_DOLLAR_SVG(true, elm.className.baseVal)}` : `${REGULAR_BLUE_DOLLAR_SVG(true, elm.className.baseVal)}`
   const smallInnerElement = MEME_MODE ? `${COMIC_SANS_BLUE_DOLLAR_SVG(false, elm.className.baseVal)}` : `${REGULAR_BLUE_DOLLAR_SVG(false, elm.className.baseVal)}`
   const big = `
-    <div style='margin-left: 0.25rem; display: flex; flex-direction: row; align-items: center;${TEXT_ENABLE_BORDER ? ` border-radius: 120px; border: 1px solid #536471;`: ``} padding: 0.1rem 0.4rem 0.1rem 0.2rem; gap: 0.2rem;' aria-label="${VERIFIED_ACCOUNT_ARIA_LABEL}" data-eight-dollars-status="blueVerified">
+    <div style='margin-left: 0.25rem; display: flex; flex-direction: row; align-items: center;${TEXT_ENABLE_BORDER ? ` border-radius: 120px; border: 1px solid #536471;`: ``} padding: 0.1rem 0.4rem 0.1rem 0.2rem; gap: ${TEXT_TWITTER_BLUE_LABEL ? 0.2 : 0}rem;' aria-label="${VERIFIED_ACCOUNT_ARIA_LABEL}" data-eight-dollars-status="blueVerified">
       ${smallInnerElement}
       <p style=' font-size: 0.8rem; margin: 0; font-weight: 600;'>${TEXT_TWITTER_BLUE_LABEL}</p>
     </div>`
@@ -285,7 +285,7 @@ function evaluateBlueCheck() {
 
       const isSmall = checkIfSmall(blueCheckComponent)
       const isKnownBadData = checkIfKnownBadData(blueCheckComponent)
-  
+
       if (isKnownBadData && nestedProps.isVerified && nestedProps.isBlueVerified) {
         changeVerified(blueCheckComponent, isSmall, true);
       } else if (nestedProps.isVerified) {
@@ -360,7 +360,7 @@ async function main() {
           trackingBlueChecksProvidesDetails.delete(blueCheckEl)
         }
       }
-    
+
       evaluateBlueCheck()
       evaluateBlueCheckProvidesDetails()
     }


### PR DESCRIPTION
There is a gap of `0.2rem` between the new verified badges and the verified text, but when user remove the text (i.e make text = "" ) then the gap of `0.2rem` looks bad and useless (bcoz gap is used to separate badge and text)

So, we can make gap = `0rem` then no text is there.

![Screenshot from 2022-11-14 16-13-32](https://user-images.githubusercontent.com/82411321/201650104-230dca03-fe04-4d5b-b4ce-19fb73e79245.png)

