### PR TITLE
Fix/text node sibling bluecheck

### DIFF
--- a/script.js
+++ b/script.js
@@ -133,7 +133,7 @@ function getOriginalClasses(elm) {
   return [...elm.classList].join(" ")
 }
 
-function changeVerified(prependText, elm, isSmall, isIndeterminate) {
+function changeVerified(prependHTML, elm, isSmall, isIndeterminate) {
   if (elm.dataset.eightDollarsStatus === 'verified') {
     // already replaced this element
     return
@@ -154,7 +154,7 @@ function changeVerified(prependText, elm, isSmall, isIndeterminate) {
       <p style=' font-size: 0.8rem; margin: 0; font-weight: 600;'>${TEXT_VERIFIED_LABEL}</p>
     </span>`;
   try {
-    if (prependText !== "") {
+    if (prependHTML !== "") {
       // Ideally, we wouldn't mutate the parent element, because those 2 styles won't be managed by us further on.
       // That is, if the `aria-label`-selected element changes, the parent styles won't be properly updated.
       // This approach is tolerable, because it's unlikely that a `aria-label`-selected element changes from a
@@ -163,16 +163,16 @@ function changeVerified(prependText, elm, isSmall, isIndeterminate) {
       elm.parentElement.style.alignItems = "center";  
     }
     if (isSmall || !TEXT_ENABLED) {
-      elm.parentElement.innerHTML = `${prependText}${small}`;
+      elm.parentElement.innerHTML = `${prependHTML}${small}`;
     } else {
-      elm.parentElement.innerHTML = `${prependText}${big}`;
+      elm.parentElement.innerHTML = `${prependHTML}${big}`;
     }
   } catch (e) {
     console.error('error changing verified', e);
   }
 }
 
-function changeBlueVerified(prependText, elm, isSmall) {
+function changeBlueVerified(prependHTML, elm, isSmall) {
   if (elm.dataset.eightDollarsStatus === 'blueVerified') {
     // already replaced this element
     return
@@ -192,7 +192,7 @@ function changeBlueVerified(prependText, elm, isSmall) {
       <p style=' font-size: 0.8rem; margin: 0; font-weight: 600;'>${TEXT_TWITTER_BLUE_LABEL}</p>
     </span>`
   try {
-    if (prependText !== "") {
+    if (prependHTML !== "") {
       // Ideally, we wouldn't mutate the parent element, because those 2 styles won't be managed by us further on.
       // That is, if the `aria-label`-selected element changes, the parent styles won't be properly updated.
       // This approach is tolerable, because it's unlikely that a `aria-label`-selected element changes from a
@@ -201,9 +201,9 @@ function changeBlueVerified(prependText, elm, isSmall) {
       elm.parentElement.style.alignItems = "center";  
     }
     if (isSmall || !TEXT_ENABLED) {
-      elm.parentElement.innerHTML = `${prependText}${small}`;
+      elm.parentElement.innerHTML = `${prependHTML}${small}`;
     } else {
-      elm.parentElement.innerHTML = `${prependText}${big}`;
+      elm.parentElement.innerHTML = `${prependHTML}${big}`;
     }
   } catch (e) {
     console.error('error changing blue verified', e);
@@ -314,14 +314,14 @@ function evaluateBlueCheck() {
 
         const isSmall = checkIfSmall(blueCheckComponent)
         const isKnownBadData = checkIfKnownBadData(blueCheckComponent)
-        const prependText = blueCheckComponent.previousElementSibling?.outerHTML
+        const prependHTML = blueCheckComponent.previousElementSibling?.outerHTML
 
         if (isKnownBadData && nestedProps.isVerified && nestedProps.isBlueVerified) {
-          changeVerified(prependText, blueCheckComponent, isSmall, true);
+          changeVerified(prependHTML, blueCheckComponent, isSmall, true);
         } else if (nestedProps.isVerified) {
-          changeVerified(prependText, blueCheckComponent, isSmall, false);
+          changeVerified(prependHTML, blueCheckComponent, isSmall, false);
         } else if (nestedProps.isBlueVerified) {
-          changeBlueVerified(prependText, blueCheckComponent, isSmall, false);
+          changeBlueVerified(prependHTML, blueCheckComponent, isSmall, false);
         }
         continue
       }

--- a/script.js
+++ b/script.js
@@ -287,6 +287,24 @@ function evaluateBlueCheck() {
       if (!nestedProps) {
         // some components don't have nested props,
         // so we can't do anything with them
+
+        const propsToLookInto = getReactProps(blueCheckComponent.parentElement.parentElement, blueCheckComponent.parentElement)
+        const nestedProps = propsToLookInto?.children[1]?.props
+
+        if (!nestedProps) {
+          continue
+        }
+
+        const isSmall = checkIfSmall(blueCheckComponent)
+        const isKnownBadData = checkIfKnownBadData(blueCheckComponent)
+
+        if (isKnownBadData && nestedProps.isVerified && nestedProps.isBlueVerified) {
+          changeVerified(blueCheckComponent, isSmall, true);
+        } else if (nestedProps.isVerified) {
+          changeVerified(blueCheckComponent, isSmall, false);
+        } else if (nestedProps.isBlueVerified) {
+          changeBlueVerified(blueCheckComponent, isSmall, false);
+        }
         continue
       }
 

--- a/script.js
+++ b/script.js
@@ -133,7 +133,7 @@ function getOriginalClasses(elm) {
   return [...elm.classList].join(" ")
 }
 
-function changeVerified(elm, isSmall, isIndeterminate) {
+function changeVerified(prependText, elm, isSmall, isIndeterminate) {
   if (elm.dataset.eightDollarsStatus === 'verified') {
     // already replaced this element
     return
@@ -149,22 +149,26 @@ function changeVerified(elm, isSmall, isIndeterminate) {
   const small = REGULAR_BLUE_CHECK_SVG(true, getOriginalClasses(elm));
   const smallInnerElement = REGULAR_BLUE_CHECK_SVG(false, getOriginalClasses(elm));
   const big =  `
-    <div style='margin-left: 0.25rem; display: flex; flex-direction: row; align-items: center;${TEXT_ENABLE_BORDER ? ` border-radius: 120px; border: 1px solid #536471;`: ``} padding: 0.1rem 0.4rem 0.1rem 0.2rem; gap: ${TEXT_VERIFIED_LABEL ? 0.2 : 0}rem;' aria-label="${VERIFIED_ACCOUNT_ARIA_LABEL}" data-eight-dollars-status="verified" data-eight-dollars-original-classes="${getOriginalClasses(elm)}">
+    <span style='margin-left: 0.25rem; display: flex; flex-direction: row; align-items: center;${TEXT_ENABLE_BORDER ? ` border-radius: 120px; border: 1px solid #536471;`: ``} padding: 0.1rem 0.4rem 0.1rem 0.2rem; gap: ${TEXT_VERIFIED_LABEL ? 0.2 : 0}rem;' aria-label="${VERIFIED_ACCOUNT_ARIA_LABEL}" data-eight-dollars-status="verified" data-eight-dollars-original-classes="${getOriginalClasses(elm)}">
       ${smallInnerElement}
       <p style=' font-size: 0.8rem; margin: 0; font-weight: 600;'>${TEXT_VERIFIED_LABEL}</p>
-    </div>`;
+    </span>`;
   try {
     if (isSmall || !TEXT_ENABLED) {
-      elm.parentElement.innerHTML = small;
+      elm.parentElement.style.display = "inline-flex";
+      elm.parentElement.style.alignItems = "center";
+      elm.parentElement.innerHTML = `${prependText + small}`;
     } else {
-      elm.parentElement.innerHTML = big;
+      elm.parentElement.style.display = "inline-flex";
+      elm.parentElement.style.alignItems = "center";
+      elm.parentElement.innerHTML = `${prependText + big}`;
     }
   } catch (e) {
     console.error('error changing verified', e);
   }
 }
 
-function changeBlueVerified(elm, isSmall) {
+function changeBlueVerified(prependText, elm, isSmall) {
   if (elm.dataset.eightDollarsStatus === 'blueVerified') {
     // already replaced this element
     return
@@ -179,15 +183,19 @@ function changeBlueVerified(elm, isSmall) {
   const small = MEME_MODE ? `${COMIC_SANS_BLUE_DOLLAR_SVG(true, getOriginalClasses(elm))}` : `${REGULAR_BLUE_DOLLAR_SVG(true, getOriginalClasses(elm))}`
   const smallInnerElement = MEME_MODE ? `${COMIC_SANS_BLUE_DOLLAR_SVG(false, getOriginalClasses(elm))}` : `${REGULAR_BLUE_DOLLAR_SVG(false, getOriginalClasses(elm))}`
   const big = `
-    <div style='margin-left: 0.25rem; display: flex; flex-direction: row; align-items: center;${TEXT_ENABLE_BORDER ? ` border-radius: 120px; border: 1px solid #536471;`: ``} padding: 0.1rem 0.4rem 0.1rem 0.2rem; gap: ${TEXT_TWITTER_BLUE_LABEL ? 0.2 : 0}rem;' aria-label="${VERIFIED_ACCOUNT_ARIA_LABEL}" data-eight-dollars-status="blueVerified" data-eight-dollars-original-classes="${getOriginalClasses(elm)}">
+    <span style='margin-left: 0.25rem; display: flex; flex-direction: row; align-items: center;${TEXT_ENABLE_BORDER ? ` border-radius: 120px; border: 1px solid #536471;`: ``} padding: 0.1rem 0.4rem 0.1rem 0.2rem; gap: ${TEXT_TWITTER_BLUE_LABEL ? 0.2 : 0}rem;' aria-label="${VERIFIED_ACCOUNT_ARIA_LABEL}" data-eight-dollars-status="blueVerified" data-eight-dollars-original-classes="${getOriginalClasses(elm)}">
       ${smallInnerElement}
       <p style=' font-size: 0.8rem; margin: 0; font-weight: 600;'>${TEXT_TWITTER_BLUE_LABEL}</p>
-    </div>`
+    </span>`
   try {
     if (isSmall || !TEXT_ENABLED) {
-      elm.parentElement.innerHTML = small;
+      elm.parentElement.style.display = "inline-flex";
+      elm.parentElement.style.alignItems = "center";
+      elm.parentElement.innerHTML = `${prependText + small}`;
     } else {
-      elm.parentElement.innerHTML = big;
+      elm.parentElement.style.display = "inline-flex";
+      elm.parentElement.style.alignItems = "center";
+      elm.parentElement.innerHTML = `${prependText + big}`;
     }
   } catch (e) {
     console.error('error changing blue verified', e);
@@ -297,13 +305,14 @@ function evaluateBlueCheck() {
 
         const isSmall = checkIfSmall(blueCheckComponent)
         const isKnownBadData = checkIfKnownBadData(blueCheckComponent)
+        const prependText = blueCheckComponent.previousElementSibling?.outerHTML
 
         if (isKnownBadData && nestedProps.isVerified && nestedProps.isBlueVerified) {
-          changeVerified(blueCheckComponent, isSmall, true);
+          changeVerified(prependText, blueCheckComponent, isSmall, true);
         } else if (nestedProps.isVerified) {
-          changeVerified(blueCheckComponent, isSmall, false);
+          changeVerified(prependText, blueCheckComponent, isSmall, false);
         } else if (nestedProps.isBlueVerified) {
-          changeBlueVerified(blueCheckComponent, isSmall, false);
+          changeBlueVerified(prependText, blueCheckComponent, isSmall, false);
         }
         continue
       }
@@ -312,11 +321,11 @@ function evaluateBlueCheck() {
       const isKnownBadData = checkIfKnownBadData(blueCheckComponent)
 
       if (isKnownBadData && nestedProps.isVerified && nestedProps.isBlueVerified) {
-        changeVerified(blueCheckComponent, isSmall, true);
+        changeVerified("", blueCheckComponent, isSmall, true);
       } else if (nestedProps.isVerified) {
-        changeVerified(blueCheckComponent, isSmall, false);
+        changeVerified("", blueCheckComponent, isSmall, false);
       } else if (nestedProps.isBlueVerified) {
-        changeBlueVerified(blueCheckComponent, isSmall, false);
+        changeBlueVerified("", blueCheckComponent, isSmall, false);
       }
     }
     catch (e) {
@@ -338,9 +347,9 @@ function evaluateBlueCheckProvidesDetails() {
       }
 
       if (nestedProps.isVerified) {
-        changeVerified(changeTarget, isSmall, false);
+        changeVerified("", changeTarget, isSmall, false);
       } else if (nestedProps.isBlueVerified) {
-        changeBlueVerified(changeTarget, isSmall, false);
+        changeBlueVerified("", changeTarget, isSmall, false);
       }
     } catch (e) {
       console.error("Error getting 'Provides details' react props: ", e)

--- a/script.js
+++ b/script.js
@@ -154,14 +154,18 @@ function changeVerified(prependText, elm, isSmall, isIndeterminate) {
       <p style=' font-size: 0.8rem; margin: 0; font-weight: 600;'>${TEXT_VERIFIED_LABEL}</p>
     </span>`;
   try {
+    if (prependText !== "") {
+      // Ideally, we wouldn't mutate the parent element, because those 2 styles won't be managed by us further on.
+      // That is, if the `aria-label`-selected element changes, the parent styles won't be properly updated.
+      // This approach is tolerable, because it's unlikely that a `aria-label`-selected element changes from a
+      // "React text node + React element node" sibling configuration to a "single React element node" sibling configuration.
+      elm.parentElement.style.display = "inline-flex";
+      elm.parentElement.style.alignItems = "center";  
+    }
     if (isSmall || !TEXT_ENABLED) {
-      elm.parentElement.style.display = "inline-flex";
-      elm.parentElement.style.alignItems = "center";
-      elm.parentElement.innerHTML = `${prependText + small}`;
+      elm.parentElement.innerHTML = `${prependText}${small}`;
     } else {
-      elm.parentElement.style.display = "inline-flex";
-      elm.parentElement.style.alignItems = "center";
-      elm.parentElement.innerHTML = `${prependText + big}`;
+      elm.parentElement.innerHTML = `${prependText}${big}`;
     }
   } catch (e) {
     console.error('error changing verified', e);
@@ -188,14 +192,18 @@ function changeBlueVerified(prependText, elm, isSmall) {
       <p style=' font-size: 0.8rem; margin: 0; font-weight: 600;'>${TEXT_TWITTER_BLUE_LABEL}</p>
     </span>`
   try {
+    if (prependText !== "") {
+      // Ideally, we wouldn't mutate the parent element, because those 2 styles won't be managed by us further on.
+      // That is, if the `aria-label`-selected element changes, the parent styles won't be properly updated.
+      // This approach is tolerable, because it's unlikely that a `aria-label`-selected element changes from a
+      // "React text node + React element node" sibling configuration to a "single React element node" sibling configuration.
+      elm.parentElement.style.display = "inline-flex";
+      elm.parentElement.style.alignItems = "center";  
+    }
     if (isSmall || !TEXT_ENABLED) {
-      elm.parentElement.style.display = "inline-flex";
-      elm.parentElement.style.alignItems = "center";
-      elm.parentElement.innerHTML = `${prependText + small}`;
+      elm.parentElement.innerHTML = `${prependText}${small}`;
     } else {
-      elm.parentElement.style.display = "inline-flex";
-      elm.parentElement.style.alignItems = "center";
-      elm.parentElement.innerHTML = `${prependText + big}`;
+      elm.parentElement.innerHTML = `${prependText}${big}`;
     }
   } catch (e) {
     console.error('error changing blue verified', e);

--- a/script.js
+++ b/script.js
@@ -305,7 +305,8 @@ function evaluateBlueCheck() {
         // so we can't do anything with them
 
         const propsToLookInto = getReactProps(blueCheckComponent.parentElement.parentElement, blueCheckComponent.parentElement)
-        const nestedProps = propsToLookInto?.children[1]?.props
+        const elementChild = propsToLookInto?.children.find(child => child.$$typeof === Symbol.for('react.element'))
+        const nestedProps = elementChild?.props
 
         if (!nestedProps) {
           continue


### PR DESCRIPTION
# Fix the case when a blue check is neighbouring a React text node

In majority of cases, a blue check is its own React element inside of a parent React element. 
In a few cases such as Notifications tab, a blue check is neighbouring a React text node.

Before:
<img width="609" alt="image" src="https://user-images.githubusercontent.com/2031472/202423391-1b600b43-9a55-47ff-bb6d-2176c3bc6b59.png">

After:
<img width="608" alt="image" src="https://user-images.githubusercontent.com/2031472/202423326-df2dd7e3-4b19-405c-9849-25f45c33e21c.png">
