### PR TITLE
Fix/multiple text node siblings

### DIFF
--- a/script.js
+++ b/script.js
@@ -220,6 +220,16 @@ function querySelectorAllIncludingMe(node, selector) {
   return [...node.querySelectorAll(selector)]
 }
 
+function getPreviusSiblingsOuterHTML(node) {
+  let prev = node.previousElementSibling;
+  let html = [];
+  while (prev) {
+    html.push(prev.outerHTML);
+    prev = prev.previousElementSibling;
+  }
+  return html.reverse().join('');
+}
+
 // From https://stackoverflow.com/a/74240138/2230249
 function getReactProps(parent, target) {
   const keyof_ReactProps = Object.keys(parent).find(k => k.startsWith("__reactProps$"));
@@ -314,7 +324,7 @@ function evaluateBlueCheck() {
 
         const isSmall = checkIfSmall(blueCheckComponent)
         const isKnownBadData = checkIfKnownBadData(blueCheckComponent)
-        const prependHTML = blueCheckComponent.previousElementSibling?.outerHTML
+        const prependHTML = getPreviusSiblingsOuterHTML(blueCheckComponent)
 
         if (isKnownBadData && nestedProps.isVerified && nestedProps.isBlueVerified) {
           changeVerified(prependHTML, blueCheckComponent, isSmall, true);

--- a/script.js
+++ b/script.js
@@ -158,7 +158,7 @@ function changeVerified(prependHTML, elm, isSmall, isIndeterminate) {
       // Ideally, we wouldn't mutate the parent element, because those 2 styles won't be managed by us further on.
       // That is, if the `aria-label`-selected element changes, the parent styles won't be properly updated.
       // This approach is tolerable, because it's unlikely that a `aria-label`-selected element changes from a
-      // "React text node + React element node" sibling configuration to a "single React element node" sibling configuration.
+      // "React text node(s) + React element node" sibling configuration to a "single React element node" sibling configuration.
       elm.parentElement.style.display = "inline-flex";
       elm.parentElement.style.alignItems = "center";  
     }
@@ -196,7 +196,7 @@ function changeBlueVerified(prependHTML, elm, isSmall) {
       // Ideally, we wouldn't mutate the parent element, because those 2 styles won't be managed by us further on.
       // That is, if the `aria-label`-selected element changes, the parent styles won't be properly updated.
       // This approach is tolerable, because it's unlikely that a `aria-label`-selected element changes from a
-      // "React text node + React element node" sibling configuration to a "single React element node" sibling configuration.
+      // "React text node(s) + React element node" sibling configuration to a "single React element node" sibling configuration.
       elm.parentElement.style.display = "inline-flex";
       elm.parentElement.style.alignItems = "center";  
     }


### PR DESCRIPTION
A follow up to the #58 fix, this PR handles the case when there are multiple React text nodes before a blue check.

Seems to be only affecting accounts with emojis in the username.

Before:
<img width="403" alt="image" src="https://user-images.githubusercontent.com/2031472/202693743-18df5422-821d-459c-97cc-6064059a39a7.png">

After:
<img width="499" alt="image" src="https://user-images.githubusercontent.com/2031472/202693791-0eab2d26-6c7e-4248-99cf-e7fce57a4dd9.png">
