### PR TITLE
Fix/console error spam

### DIFF
--- a/script.js
+++ b/script.js
@@ -210,7 +210,7 @@ function changeBlueVerified(prependHTML, elm, isSmall) {
   }
 }
 
-const BLUE_CHECK_PATTERN_NEW = `[aria-label="${VERIFIED_ACCOUNT_ARIA_LABEL}"]`
+const BLUE_CHECK_PATTERN_NEW = `:not([aria-label="${PROVIDES_DETAILS_ARIA_LABEL}"]) > [aria-label="${VERIFIED_ACCOUNT_ARIA_LABEL}"]`
 const BLUE_CHECK_PATTERN_PROVIDE_DETAILS = `[aria-label="${PROVIDES_DETAILS_ARIA_LABEL}"]`
 
 function querySelectorAllIncludingMe(node, selector) {


### PR DESCRIPTION
When going to a user profile that has a bluecheck, console would spam `children.find is not a function`.

This was happening because `BLUE_CHECK_PATTERN_PROVIDE_DETAILS` bluecheck would get processed twice. Once when getting selected by `BLUE_CHECK_PATTERN_PROVIDE_DETAILS`, and the second time when getting selected by `BLUE_CHECK_PATTERN_NEW`.

The solution is to process each bluecheck type once.

User experience is the same before/after, just removes console errors.