### PR TITLE
Fix/disable advanced search

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,5 +1,6 @@
 const defaultConfig = {
   advancedSearch: false,
+  advancedSearchMigratedToFalseOnce: false,
   memeMode: false,
   textEnabled: true,
   removeBlueVerification: false,
@@ -38,10 +39,26 @@ function injectSearch() {
 
 if (typeof chrome !== "undefined" && chrome.storage) {
   chrome.storage.local.get(defaultConfig, function (items) {
-    createSettingsDomNode(items);
-    injectScript();
-    if (items.advancedSearch) {
-      injectSearch();
+    if (!items.advancedSearchMigratedToFalseOnce) {
+      chrome.storage.local.set({
+        advancedSearch: false,
+        advancedSearchMigratedToFalseOnce: true,
+      }, function () {
+        items.advancedSearch = false;
+        items.advancedSearchMigratedToFalseOnce = true;
+        createSettingsDomNode(items);
+        injectScript();
+        if (items.advancedSearch) {
+          injectSearch();
+        }
+      })
+    }
+    else {
+      createSettingsDomNode(items);
+      injectScript();
+      if (items.advancedSearch) {
+        injectSearch();
+      }
     }
   });
 } else {

--- a/content.js
+++ b/content.js
@@ -1,5 +1,5 @@
 const defaultConfig = {
-  advancedSearch: true,
+  advancedSearch: false,
   memeMode: false,
   textEnabled: true,
   removeBlueVerification: false,

--- a/options/options.js
+++ b/options/options.js
@@ -46,7 +46,7 @@ function closeOptions() {
 function restoreOptions() {
   chrome.storage.local.get(
     {
-      advancedSearch: true,
+      advancedSearch: false,
       memeMode: false,
       textEnabled: true,
       removeBlueVerification: false,

--- a/options/options.js
+++ b/options/options.js
@@ -47,6 +47,7 @@ function restoreOptions() {
   chrome.storage.local.get(
     {
       advancedSearch: false,
+      advancedSearchMigratedToFalseOnce: false,
       memeMode: false,
       textEnabled: true,
       removeBlueVerification: false,


### PR DESCRIPTION
# Change summary
- disables Advanced Search by default
- one-time forces Advanced Search to be off for everyone

# Upgrade scenarios tested

## Scenario 1

Steps
- v1.5 installed
- nothing done to settings
- `fix/disable_advanced_search` installed

Result
- advanced search is off

## Scenario 2

Steps
- v1.5 installed
- settings changed & saved
- `fix/disable_advanced_search` installed

Result
- advanced search is off