### PR TITLE
Fix script.js function name and reference spelling error

### DIFF
--- a/script.js
+++ b/script.js
@@ -220,7 +220,7 @@ function querySelectorAllIncludingMe(node, selector) {
   return [...node.querySelectorAll(selector)]
 }
 
-function getPreviusSiblingsOuterHTML(node) {
+function getPreviousSiblingsOuterHTML(node) {
   let prev = node.previousElementSibling;
   let html = [];
   while (prev) {
@@ -324,7 +324,7 @@ function evaluateBlueCheck() {
 
         const isSmall = checkIfSmall(blueCheckComponent)
         const isKnownBadData = checkIfKnownBadData(blueCheckComponent)
-        const prependHTML = getPreviusSiblingsOuterHTML(blueCheckComponent)
+        const prependHTML = getPreviousSiblingsOuterHTML(blueCheckComponent)
 
         if (isKnownBadData && nestedProps.isVerified && nestedProps.isBlueVerified) {
           changeVerified(prependHTML, blueCheckComponent, isSmall, true);


### PR DESCRIPTION
The function `getPreviusSiblingsOuterHTML(node)` in script.js is spelled incorrectly. This pull request fixes this spelling error in two places: where the function is defined and the one location where it is used.